### PR TITLE
Stick to Node LTS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   # Publish the image set to S3
   publish:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:10
     steps:
       - checkout
       - run: git config --global user.email "origami.support@ft.com";


### PR DESCRIPTION
libxmljs@0.19.5 failed to build for node@12.0.0
https://circleci.com/gh/Financial-Times/headshot-images/612?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification